### PR TITLE
Update explorer config to fix field names

### DIFF
--- a/config/vpodcprod/explorer.json
+++ b/config/vpodcprod/explorer.json
@@ -113,13 +113,13 @@
         {
           "title": "Files",
           "fields": [
-            "_project_id",
+            "project_id",
             "data_type",
             "data_format",
             "file_size"
           ], 
           "fieldsConfig" : {
-            "_project_id": {
+            "project_id": {
               "label": "Project Id"
             },
             "data_type": {
@@ -148,7 +148,7 @@
     "table": {
       "enabled": true,
       "fields": [
-        "_case_submitter_id",
+        "submitter_id",
         "data_type",
         "data_format",
         "file_name",
@@ -156,7 +156,7 @@
         "object_id"
       ], 
       "columns": {
-        "_case_submitter_id": {
+        "submitter_id": {
           "title": "Case Submitter ID"
         },
         "data_type": {


### PR DESCRIPTION
Rename '_project_id' to 'project_id' and '_case_submitter_id' to 'submitter_id'